### PR TITLE
minimumUSD should use eth price

### DIFF
--- a/FundMe.sol
+++ b/FundMe.sol
@@ -17,7 +17,7 @@ contract FundMe {
     }
     
     function fund() public payable {
-        uint256 minimumUSD = 50 * 10 ** 18;
+        uint256 minimumUSD = (50 / getPrice()) * 10 ** 18;
         require(getConversionRate(msg.value) >= minimumUSD, "You need to spend more ETH!");
         addressToAmountFunded[msg.sender] += msg.value;
         funders.push(msg.sender);


### PR DESCRIPTION
The current minimumUSD price doesn't take in to account the eth <-> USD exchange rate. This should be updated to call getPrice().