### PR TITLE
changing  a wd function to an alternative

### DIFF
--- a/FundMe.sol
+++ b/FundMe.sol
@@ -2,7 +2,7 @@
 
 // Smart contract that lets anyone deposit ETH into the contract
 // Only the owner of the contract can withdraw the ETH
-pragma solidity ^0.6.6 <0.9.0;
+pragma solidity ^0.8.0;
 
 // Get the latest ETH/USD price from chainlink price feed
 
@@ -83,8 +83,10 @@ contract FundMe {
     // onlyOwner modifer will first check the condition inside it
     // and
     // if true, withdraw function will be executed
-    function withdraw() public payable onlyOwner {
-        msg.sender.transfer(address(this).balance);
+    function withdraw() public {
+    address payable sender = payable(msg.sender);
+    sender.transfer(address(this).balance);
+    }
 
         //iterate through all the mappings and make them 0
         //since all the deposited amount has been withdrawn


### PR DESCRIPTION
### Big Thanks to freeCodeCamp

I am currently learning blockchain development with freeCodeCamp full course on YouTube. It is very helpful and easy to understand. However I found an error in Patrick's file, to be exact, at the withdraw function.
<img width="557" alt="image" src="https://github.com/PatrickAlphaC/fund_me/assets/98252071/280c0306-5f25-4609-88cb-ebd056c9a5c8">

 My assumption is because Patrick is using ^0.6.0 => 0.9.0 version of solidity. And by my time, 2023, it seems I'm not able to use that version of solidity. Remix IDE keeps forcing me to use ^0.8.0 version of solidity.
<img width="619" alt="image" src="https://github.com/PatrickAlphaC/fund_me/assets/98252071/68d26e27-92ba-40d5-8187-73b903f5b1c2">


I hope this could help the community who are dealing with the same problem with me. Once again thanks to freeCodeCamp and Patrick who are willing to give their priceless knowldege FOR FREE so that people from all around the world could learn easily, happily.

Solidity, Blockchain, and Smart Contract Course – Beginner to Expert Python Tutorial : [https://youtu.be/M576WGiDBdQ?si=s46p_9HWoipgxh2-](url) 